### PR TITLE
[#263] 조회기록, 이탈기록 API share token 지원

### DIFF
--- a/src/controllers/analytics.controller.js
+++ b/src/controllers/analytics.controller.js
@@ -34,11 +34,11 @@ import {
  *           schema:
  *             type: object
  *             required:
- *               - projectId
+ *               - shareToken
  *             properties:
- *               projectId:
- *                 type: integer
- *                 description: 프로젝트 ID
+ *               shareToken:
+ *                 type: string
+ *                 description: 공유 링크 토큰
  *     responses:
  *       200:
  *         description: 기록 성공
@@ -68,7 +68,7 @@ import {
 export const handleRecordPageView = async (req, res, next) => {
   try {
     const result = await recordPageView({
-      projectId: req.body.projectId,
+      shareToken: req.body.shareToken,
       sessionId: req.user?.sessionId,
     });
     res.json(result);
@@ -219,11 +219,11 @@ export const handleRecordVideoEvent = async (req, res, next) => {
  *           schema:
  *             type: object
  *             required:
- *               - projectId
+ *               - shareToken
  *             properties:
- *               projectId:
- *                 type: integer
- *                 description: 프로젝트 ID
+ *               shareToken:
+ *                 type: string
+ *                 description: 공유 링크 토큰
  *               lastSlideId:
  *                 type: integer
  *                 description: 마지막으로 본 슬라이드 ID
@@ -262,7 +262,7 @@ export const handleRecordVideoEvent = async (req, res, next) => {
 export const handleRecordExit = async (req, res, next) => {
   try {
     const result = await recordExit({
-      projectId: req.body.projectId,
+      shareToken: req.body.shareToken,
       sessionId: req.user?.sessionId,
       lastSlideId: req.body.lastSlideId,
       lastVideoId: req.body.lastVideoId,

--- a/src/repositories/shareLink.repository.js
+++ b/src/repositories/shareLink.repository.js
@@ -157,6 +157,14 @@ export const getVideoList = async (projectId, page, pageSize) => {
   return { totalCount, videos };
 };
 
+// shareToken으로 projectId 경량 조회
+export const findProjectIdByShareToken = async (token) => {
+  return await prisma.shareLink.findFirst({
+    where: { shareToken: token },
+    select: { projectId: true, isActive: true, expiredAt: true },
+  });
+};
+
 // 삭제된 프로젝트인지 확인
 export const findProjectById = async (projectId) => {
   return await prisma.project.findUnique({

--- a/src/services/analytics.service.js
+++ b/src/services/analytics.service.js
@@ -6,6 +6,7 @@ import {
   AnalyticsSessionRequiredError,
 } from "../errors/analytics.error.js";
 import * as analyticsRepository from "../repositories/analytics.repository.js";
+import * as shareLinkRepository from "../repositories/shareLink.repository.js";
 import { findRecentVideoCommentsByProjectId } from "../repositories/comment.repository.js";
 import { findSlideByTimestamp } from "../repositories/video.repository.js";
 import { toPublicStorageUrl } from "../utils/storageUrl.util.js";
@@ -16,17 +17,12 @@ import { toPublicStorageUrl } from "../utils/storageUrl.util.js";
  * 페이지 조회 기록
  * POST /analytics/pageview
  */
-export const recordPageView = async ({ projectId, sessionId }) => {
+export const recordPageView = async ({ shareToken, sessionId }) => {
   if (!sessionId) {
     throw new AnalyticsSessionRequiredError();
   }
 
-  const pid = requireProjectId(projectId);
-
-  const project = await analyticsRepository.findProjectById(pid);
-  if (!project) {
-    throw new AnalyticsProjectNotFoundError({ projectId: pid });
-  }
+  const pid = await resolveProjectIdByShareToken(shareToken);
 
   await analyticsRepository.createPageView({ projectId: pid, sessionId });
 
@@ -113,7 +109,7 @@ export const recordVideoEvent = async ({ videoId, eventType, timestampMs, sessio
  * POST /analytics/exit
  */
 export const recordExit = async ({
-  projectId,
+  shareToken,
   sessionId,
   lastSlideId,
   lastVideoId,
@@ -123,12 +119,7 @@ export const recordExit = async ({
     throw new AnalyticsSessionRequiredError();
   }
 
-  const pid = requireProjectId(projectId);
-
-  const project = await analyticsRepository.findProjectById(pid);
-  if (!project) {
-    throw new AnalyticsProjectNotFoundError({ projectId: pid });
-  }
+  const pid = await resolveProjectIdByShareToken(shareToken);
 
   const data = {
     projectId: pid,
@@ -136,10 +127,20 @@ export const recordExit = async ({
   };
 
   if (lastSlideId) {
-    data.lastSlideId = toInt(lastSlideId);
+    const sid = toInt(lastSlideId);
+    const slide = await analyticsRepository.findSlideById(sid);
+    if (!slide) {
+      throw new AnalyticsSlideNotFoundError({ slideId: sid });
+    }
+    data.lastSlideId = sid;
   }
   if (lastVideoId) {
-    data.lastVideoId = toInt(lastVideoId);
+    const vid = toInt(lastVideoId);
+    const video = await analyticsRepository.findVideoById(vid);
+    if (!video) {
+      throw new AnalyticsVideoNotFoundError({ videoId: vid });
+    }
+    data.lastVideoId = vid;
   }
   if (lastVideoTimeMs !== undefined && lastVideoTimeMs !== null) {
     data.lastVideoTimeMs = toInt(lastVideoTimeMs);
@@ -473,6 +474,25 @@ export const getRecentComments = async ({ projectId, limit = 10 }) => {
 };
 
 // ==================== Helper Functions ====================
+
+const resolveProjectIdByShareToken = async (shareToken) => {
+  if (!shareToken) {
+    throw new AnalyticsInvalidParameterError({ shareToken }, "shareToken이 필요합니다.");
+  }
+
+  const shareLink = await shareLinkRepository.findProjectIdByShareToken(shareToken);
+  if (!shareLink) {
+    throw new AnalyticsProjectNotFoundError({ shareToken });
+  }
+  if (!shareLink.isActive) {
+    throw new AnalyticsInvalidParameterError({ shareToken }, "비활성화된 공유 링크입니다.");
+  }
+  if (shareLink.expiredAt && shareLink.expiredAt < new Date()) {
+    throw new AnalyticsInvalidParameterError({ shareToken }, "만료된 공유 링크입니다.");
+  }
+
+  return Number(shareLink.projectId);
+};
 
 const toInt = (value) => {
   const n = typeof value === "string" ? Number(value) : value;

--- a/src/socket/handlers/room.handler.js
+++ b/src/socket/handlers/room.handler.js
@@ -1,13 +1,27 @@
-export const registerRoomHandlers = (io, socket) => {
-  
-  socket.on("join-project", (data) => {
-    const { projectId } = data;
+import { findProjectIdByShareToken } from "../../repositories/shareLink.repository.js";
 
-    if (!projectId) {
-      socket.emit("error", { message: "projectId is required" });
+export const registerRoomHandlers = (io, socket) => {
+
+  socket.on("join-project", async (data) => {
+    const { shareToken } = data;
+
+    if (!shareToken) {
+      socket.emit("error", { message: "shareToken is required" });
       return;
     }
 
+    // shareToken → projectId 변환
+    const shareLink = await findProjectIdByShareToken(shareToken);
+    if (!shareLink || !shareLink.isActive) {
+      socket.emit("error", { message: "유효하지 않은 공유 링크입니다." });
+      return;
+    }
+    if (shareLink.expiredAt && shareLink.expiredAt < new Date()) {
+      socket.emit("error", { message: "만료된 공유 링크입니다." });
+      return;
+    }
+
+    const projectId = Number(shareLink.projectId);
     const roomName = `project:${projectId}`;
 
     // Room 입장
@@ -28,14 +42,21 @@ export const registerRoomHandlers = (io, socket) => {
 
   });
 
-  socket.on("leave-project", (data) => {
-    const { projectId } = data;
+  socket.on("leave-project", async (data) => {
+    const { shareToken } = data;
 
-    if (!projectId) {
-      socket.emit("error", { message: "projectId is required" });
+    if (!shareToken) {
+      socket.emit("error", { message: "shareToken is required" });
       return;
     }
 
+    const shareLink = await findProjectIdByShareToken(shareToken);
+    if (!shareLink) {
+      socket.emit("error", { message: "유효하지 않은 공유 링크입니다." });
+      return;
+    }
+
+    const projectId = Number(shareLink.projectId);
     const roomName = `project:${projectId}`;
 
     // Room 퇴장


### PR DESCRIPTION
…처리 강화

## 🔗 관련 이슈
- closes #263 

## ✨ 변경 내용
- 기존에 projectId를 request body로 받는 로직을 shareToken으로 받아 projectId를 추출하는 방식으로 전환
- 이탈기록 api에 잘못된 슬라이드 및 비디오 id를 넣었을 때 500뜨던 에러처리를 강화

## ✅ 체크리스트
- [x] 로컬에서 테스트 통과