### PR TITLE
[#273]conversionJob 생성시 projectId 전달

### DIFF
--- a/src/repositories/conversionJob.repository.js
+++ b/src/repositories/conversionJob.repository.js
@@ -1,10 +1,11 @@
 import { prisma } from "../db.config.js";
 
-export const createConversionJob = async ({ uploadedFileId, videoId, jobType }) => {
+export const createConversionJob = async ({ uploadedFileId, videoId, jobType, projectId }) => {
   return await prisma.conversionJob.create({
     data: {
       uploadedFileId: uploadedFileId ?? null,
       videoId: videoId ?? null,
+      projectId: projectId ?? null,
       jobType,
       status: "queued",
       progress: 0,

--- a/src/services/conversionJob.service.js
+++ b/src/services/conversionJob.service.js
@@ -15,8 +15,8 @@ import { videoTranscode } from "./conversion/videoTranscode.service.js";
 /**
  * 작업 생성 및 큐에 추가
  */
-const createAndEnqueueJob = async ({ uploadedFileId, videoId, jobType }) => {
-  const job = await createConversionJob({ uploadedFileId, videoId, jobType });
+const createAndEnqueueJob = async ({ uploadedFileId, videoId, jobType, projectId }) => {
+  const job = await createConversionJob({ uploadedFileId, videoId, jobType, projectId });
 
   if (!process.env.GCP_PROJECT_ID || !process.env.CLOUD_RUN_SERVICE_URL) {
     // 로컬 테스트용
@@ -68,6 +68,7 @@ const chainThumbnailJob = async (parentJobId) => {
     const thumbnailJob = await createAndEnqueueJob({
       uploadedFileId: parentJob.uploadedFileId,
       jobType: "generate_thumbnail",
+      projectId: parentJob.projectId,
     });
 
     console.log(`Chained thumbnail job ${thumbnailJob.id} from parent ${parentJobId}`);
@@ -91,6 +92,7 @@ const chainMetadataJob = async (parentJobId) => {
     const metadataJob = await createAndEnqueueJob({
       uploadedFileId: parentJob.uploadedFileId,
       jobType: "extract_metadata",
+      projectId: parentJob.projectId,
     });
 
     console.log(`Chained metadata job ${metadataJob.id} from parent ${parentJobId}`);
@@ -146,7 +148,7 @@ export const processJob = async (conversionJobId, jobType) => {
  *    - generate_thumbnail
  *    - extract_metadata
  */
-export const startConversionPipeline = async ({ uploadedFileId, fileExt }) => {
+export const startConversionPipeline = async ({ uploadedFileId, fileExt, projectId }) => {
   const ext = fileExt.toLowerCase();
 
   let imageConversionJobType;
@@ -163,6 +165,7 @@ export const startConversionPipeline = async ({ uploadedFileId, fileExt }) => {
   const imageJob = await createAndEnqueueJob({
     uploadedFileId,
     jobType: imageConversionJobType,
+    projectId,
   });
 
   console.log(`[Pipeline] Started for file ${uploadedFileId}:`, {
@@ -179,11 +182,12 @@ export const startConversionPipeline = async ({ uploadedFileId, fileExt }) => {
  *
  * - video_transcode: 청크 병합 → HLS 변환 → GCS 업로드
  */
-export const startVideoEncodingPipeline = async ({ videoId, uploadedFileId }) => {
+export const startVideoEncodingPipeline = async ({ videoId, uploadedFileId, projectId }) => {
   const job = await createAndEnqueueJob({
     videoId,
     uploadedFileId,
     jobType: "video_transcode",
+    projectId,
   });
 
   console.log(`[Pipeline] Video encoding started for video ${videoId}:`, {

--- a/src/services/files.service.js
+++ b/src/services/files.service.js
@@ -70,6 +70,7 @@ export async function uploadPresentationAndCreateProject({ userId, title, file }
     await startConversionPipeline({
       uploadedFileId: uf.id,
       fileExt: ext,
+      projectId: project.id,
     });
   }
 

--- a/src/services/project.service.js
+++ b/src/services/project.service.js
@@ -22,6 +22,7 @@ export const processCreateProject = async (userId, projectData) => {
   await startConversionPipeline({
     uploadedFileId: BigInt(uploadedFileId),
     fileExt: file.fileExt,
+    projectId: project.id,
   });
 
   return project;

--- a/src/services/video.service.js
+++ b/src/services/video.service.js
@@ -362,7 +362,7 @@ export async function finishRecording({ videoId, slideLogs, userId }) {
   const slideDurations = await findVideoSlideDurations(vid);
 
   // 인코딩 파이프라인 시작
-  await startVideoEncodingPipeline({ videoId: vid });
+  await startVideoEncodingPipeline({ videoId: vid, projectId: video.projectId });
 
   return {
     resultType: "SUCCESS",


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #273 

## ✨ 변경 내용
- conversionJob 생성시 projectId를 넘겨줌
- 비디오 변환, 이미지 변환과 체이닝되어있는 작업 전부 반영

## ✅ 체크리스트
- [x] 로컬에서 빌드/테스트 통과