### PR TITLE
[#333] 카카오 로그인 프로필 사진 버그 해결

### DIFF
--- a/src/auth.config.js
+++ b/src/auth.config.js
@@ -55,6 +55,7 @@ export const kakaoStrategy = new KakaoStrategy(
     clientID: process.env.PASSPORT_KAKAO_CLIENT_ID,
     clientSecret: process.env.PASSPORT_KAKAO_CLIENT_SECRET, // 필요 시 설정
     callbackURL: "/auth/kakao/callback",
+    scope: ["profile_nickname", "profile_image", "account_email"],
   },
   async (accessToken, refreshToken, profile, cb) => {
     try {

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -51,6 +51,7 @@ export const socialLoginVerification = async (profile, provider) => {
     name = profile.displayName || profile._json?.properties?.nickname;
     profileImageUrl =
       profile._json?.kakao_account?.profile?.profile_image_url ||
+      profile._json?.kakao_account?.profile?.thumbnail_image_url ||
       profile._json?.properties?.profile_image ||
       profile._json?.properties?.thumbnail_image ||
       null;


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #333 

## ✨ 변경 내용
- 카카오 로그인 스코프 확장: auth.config.js 내 카카오 전략의 스코프에 profile_image를 추가하여 프로필 사진 접근 권한을 확보했습니다.
- 이미지 추출 로직 필드 보강: kakao_account.profile.thumbnail_image_url 필드를 추가로 확인하도록 수정하여, 특정 상황에서 profile_image_url이 누락되더라도 이미지를 가져올 수 있도록 방어 로직을 강화했습니다.
- 응답 안정성 향상: 카카오 동의 항목 미설정으로 인해 kakao_account.profile 객체가 비어 오는 상황에 대한 예외 처리를 보완했습니다.

## ✅ 체크리스트
- [ ] 로컬에서 빌드/테스트 통과
- [ ] 관련 문서(README, API 문서 등) 업데이트
- [ ] Breaking Change 여부 확인 (있다면 아래에 명시)


테스트 팁: 이미 동의한 기존 계정은 스코프 변경사항이 즉시 적용되지 않을 수 있습니다. 테스트 시 카카오 계정 연결 해제 후 재로그인을 권장합니다.