### PR TITLE
[#356] 공유 콘텐츠 조회가 항상 null인 videoUrl을 참조하던 문제 수정

### DIFF
--- a/src/controllers/shareLink.controller.js
+++ b/src/controllers/shareLink.controller.js
@@ -178,7 +178,7 @@ export const handleCreateShareLink = async (req, res, next) => {
  *                       timestampMs: 45000
  *                   video:
  *                     videoId: "456"
- *                     videoUrl: "https://..."
+ *                     hlsMasterUrl: "https://..."
  *                     thumbnailUrl: "https://..."
  *                   comments:
  *                     - commentId: "1"

--- a/src/services/shareLink.service.js
+++ b/src/services/shareLink.service.js
@@ -189,7 +189,7 @@ export const processGetShareContent = async (shareToken, sessionId = null) => {
   if (scope === SCOPE_VIDEO && video) {
     content.video = {
       videoId: video.id.toString(),
-      videoUrl: toPublicStorageUrl(video.sourceUrl),
+      hlsMasterUrl: toPublicStorageUrl(video.hlsMasterUrl ?? video.sourceUrl),
       thumbnailUrl: toPublicStorageUrl(video.thumbnailUrl),
     };
   }


### PR DESCRIPTION
요약
- 공유 링크 API 응답 스키마에서 오해 소지가 있는 `videoUrl` 대신 `hlsMasterUrl`을 노출하도록 정리했습니다.
- 공유 영상 payload가 실제 스트리밍 URL을 전달하도록 `hlsMasterUrl`을 우선 사용하고, 없을 때는 `sourceUrl`로 폴백하도록 변경했습니다.

테스트
- 실행하지 않음 (요청 없음)
